### PR TITLE
add  Settings.Timezone

### DIFF
--- a/DavProps.c
+++ b/DavProps.c
@@ -238,7 +238,7 @@ char *HTTPServerPropFindItemPropsXML(char *InBuff, char *ItemName, int FileType,
         {
         case PROP_CREATE_DATE:
 //<D:creationdate xmlns:D="DAV:">2008-12-18T01-47-04-0800</D:creationdate>
-            ValBuff=CopyStr(ValBuff,GetDateStrFromSecs("%Y-%m-%dT%H:%M:%SZ",atoi(Curr->Item),NULL));
+            ValBuff=CopyStr(ValBuff,GetDateStrFromSecs("%Y-%m-%dT%H:%M:%SZ",atoi(Curr->Item),Settings.Timezone));
             RetStr=MCatStr(RetStr,"<creationdate>",ValBuff,"</creationdate>\n",NULL);
             break;
 
@@ -273,7 +273,7 @@ char *HTTPServerPropFindItemPropsXML(char *InBuff, char *ItemName, int FileType,
             break;
 
         case PROP_LASTMODIFIED:
-            ValBuff=CopyStr(ValBuff,GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S %Z",atoi(Curr->Item),NULL));
+            ValBuff=CopyStr(ValBuff,GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S %Z",atoi(Curr->Item),Settings.Timezone));
             RetStr=MCatStr(RetStr,"<getlastmodified>",ValBuff,"</getlastmodified>\n",NULL);
             break;
 

--- a/FileDetailsPage.c
+++ b/FileDetailsPage.c
@@ -31,13 +31,13 @@ char *FormatFileProperties(char *HTML, HTTPSession *Session, int FType, const ch
     ptr=GetVar(Vars,"MTime-Secs");
     if (ptr)
     {
-        HTML=MCatStr(HTML,"<tr><td>Modify Time</td><td colspan=2>",GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",atoi(ptr),NULL),"</td></tr>",NULL);
+        HTML=MCatStr(HTML,"<tr><td>Modify Time</td><td colspan=2>",GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",atoi(ptr),Settings.Timezone),"</td></tr>",NULL);
     }
 
     ptr=GetVar(Vars,"CTime-Secs");
     if (ptr)
     {
-        HTML=MCatStr(HTML,"<tr><td>Create Time</td><td colspan=2>",GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",atoi(ptr),NULL),"</td></tr>",NULL);
+        HTML=MCatStr(HTML,"<tr><td>Create Time</td><td colspan=2>",GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",atoi(ptr),Settings.Timezone),"</td></tr>",NULL);
     }
 
     HTML=MCatStr(HTML,"<tr bgcolor=#CCFFCC><td>ContentType</td><td colspan=2>",GetVar(Vars,"ContentType"),"</td></tr>",NULL);

--- a/directory_listing.c
+++ b/directory_listing.c
@@ -362,7 +362,7 @@ static char *FormatFancyDirItem(char *RetStr, int count, TPathItem *File, const 
     {
         DateStr=FormatStr(DateStr,"<font color=red>%d seconds ago</font>",Now - File->Mtime);
     }
-    else DateStr=CopyStr(DateStr,GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",File->Mtime,NULL));
+    else DateStr=CopyStr(DateStr,GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",File->Mtime,Settings.Timezone));
 
     FileType=FormatFileType(FileType, File, Vars, MimeIconsURL);
     //Okay, start building the actual table row
@@ -532,8 +532,8 @@ static char *FinalizeDirListHTML(char *Buffer, HTTPSession *Session, const char 
         HTML=CatStr(HTML, "<tr><td>\n");
         //UserName might be blank if we are running without authentication
         if (StrValid(Session->UserName)) HTML=MCatStr(HTML, "User: ", Session->UserName,"<br/>",NULL);
-        HTML=MCatStr(HTML, "Date: ", GetDateStrFromSecs("%Y/%m/%d", Now, NULL), "<br/>", NULL);
-        HTML=MCatStr(HTML, "Time: ", GetDateStrFromSecs("%H:%M:%S", Now, NULL), "<br/>", NULL);
+        HTML=MCatStr(HTML, "Date: ", GetDateStrFromSecs("%Y/%m/%d", Now, Settings.Timezone), "<br/>", NULL);
+        HTML=MCatStr(HTML, "Time: ", GetDateStrFromSecs("%H:%M:%S", Now, Settings.Timezone), "<br/>", NULL);
         if (Settings.Flags & FLAG_LOGOUT_AVAILABLE) HTML=MCatStr(HTML,"<a href=\"",GetLogoutPath(),"\">( Logout )</a>",NULL);
         HTML=CatStr(HTML, "</td><td>\n");
 
@@ -760,7 +760,7 @@ static void DirectorySendCSV(STREAM *S, HTTPSession *Session, const char *Path, 
     {
         stat(Files[i]->Path,&Stat);
         SizeStr=FormatStr(SizeStr,"%d",Stat.st_size);
-        CSV=MCatStr(CSV,"\"",GetBasename(Files[i]->Path),"\", \"",Files[i]->URL,"\", \"",GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",Stat.st_mtime,NULL),"\", \"",SizeStr,"\"\r\n",NULL);
+        CSV=MCatStr(CSV,"\"",GetBasename(Files[i]->Path),"\", \"",Files[i]->URL,"\", \"",GetDateStrFromSecs("%Y/%m/%d %H:%M:%S",Stat.st_mtime,Settings.Timezone),"\", \"",SizeStr,"\"\r\n",NULL);
     }
 
     Tempstr=MCopyStr(Tempstr,Path,".csv",NULL);

--- a/libUseful/Http.c
+++ b/libUseful/Http.c
@@ -876,7 +876,7 @@ void HTTPSendHeaders(STREAM *S, HTTPInfoStruct *Info)
 
     if (Info->IfModifiedSince > 0)
     {
-        Tempstr=CopyStr(Tempstr,GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S GMT",Info->IfModifiedSince,NULL));
+        Tempstr=CopyStr(Tempstr,GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S GMT",Info->IfModifiedSince,Settings.Timezone));
         SendStr=MCatStr(SendStr,"If-Modified-Since: ",Tempstr, "\r\n",NULL);
     }
 

--- a/libUseful/Log.c
+++ b/libUseful/Log.c
@@ -151,8 +151,8 @@ char *LogFileInternalGetRotateDestinationPath(char *RetStr, TLogFile *LogFile)
     Tempstr=CopyStr(Tempstr, STREAMGetValue(LogFile->S,"RotatePath"));
     if (StrLen(Tempstr) && strchr(Tempstr,'$'))
     {
-        STREAMSetValue(LogFile->S, "Date",GetDateStr("%Y_%m_%d",NULL));
-        STREAMSetValue(LogFile->S, "Time",GetDateStr("%H:%M:%S",NULL));
+        STREAMSetValue(LogFile->S, "Date",GetDateStr("%Y_%m_%d",Settings.Timezone));
+        STREAMSetValue(LogFile->S, "Time",GetDateStr("%H:%M:%S",Settings.Timezone));
         RetStr=SubstituteVarsInString(RetStr,Tempstr,LogFile->S->Values,0);
     }
     else RetStr=CopyStr(RetStr,LogFile->Path);
@@ -270,7 +270,7 @@ int LogFileInternalWrite(TLogFile *LF, STREAM *S, int Flags, const char *Str)
 
     if (Flags & LOGFILE_TIMESTAMP)
     {
-        LogStr=CopyStr(LogStr, GetDateStr("%Y/%m/%d %H:%M:%S",NULL));
+        LogStr=CopyStr(LogStr, GetDateStr("%Y/%m/%d %H:%M:%S",Settings.Timezone));
 				
         if (Flags & LOGFILE_MILLISECS)
         {

--- a/libUseful/Smtp.c
+++ b/libUseful/Smtp.c
@@ -275,7 +275,7 @@ int SMTPSendMail(const char *Sender, const char *Recipient, const char *Subject,
     {
         if (! (Flags & SMTP_NOHEADER))
         {
-            Tempstr=MCopyStr(Tempstr,"Date: ", GetDateStr("%a, %d %b %Y %H:%M:%S", NULL), "\r\n", NULL);
+            Tempstr=MCopyStr(Tempstr,"Date: ", GetDateStr("%a, %d %b %Y %H:%M:%S", Settings.Timezone), "\r\n", NULL);
             Tempstr=MCatStr(Tempstr,"From: ", Sender, "\r\n", NULL);
             Tempstr=MCatStr(Tempstr,"To: ", Recipient, "\r\n", NULL);
             Tempstr=MCatStr(Tempstr,"Subject: ", Subject, "\r\n\r\n", NULL);

--- a/proxy.c
+++ b/proxy.c
@@ -49,7 +49,7 @@ static void HTTPProxySendResponse(STREAM *S, const char *Response)
     char *Date=NULL;
 
     STREAMWriteLine(Response,S);
-    Date=CopyStr(Date,GetDateStr("Date: %a, %d %b %Y %H:%M:%S %Z\r\n",NULL));
+    Date=CopyStr(Date,GetDateStr("Date: %a, %d %b %Y %H:%M:%S %Z\r\n",Settings.Timezone));
     STREAMWriteLine(Date,S);
     STREAMWriteLine("Connection: close\r\n",S);
     STREAMWriteLine("\r\n",S);

--- a/server.c
+++ b/server.c
@@ -493,7 +493,7 @@ void HTTPServerSendHeaders(STREAM *S, HTTPSession *Session, int Flags)
 
     HTTPServerSendHeader(S,"Date",GetDateStr("%a, %d %b %Y %H:%M:%S %Z",NULL));
 
-    if (Session->LastModified > 0) HTTPServerSendHeader(S,"Last-Modified",GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S %Z", Session->LastModified,NULL));
+    if (Session->LastModified > 0) HTTPServerSendHeader(S,"Last-Modified",GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S %Z", Session->LastModified,Settings.Timezone));
 
     if (Flags & HEADERS_AUTH)
     {
@@ -551,7 +551,7 @@ void HTTPServerSendHeaders(STREAM *S, HTTPSession *Session, int Flags)
         {
             Tempstr=FormatStr(Tempstr,"max-age=%d", Session->CacheTime);
             HTTPServerSendHeader(S, "Cache-Control", Tempstr);
-            HTTPServerSendHeader(S,"Expires",GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S %Z",time(NULL) + Session->CacheTime,NULL));
+            HTTPServerSendHeader(S,"Expires",GetDateStrFromSecs("%a, %d %b %Y %H:%M:%S %Z",time(NULL) + Session->CacheTime,Settings.Timezone));
         }
         else
         {
@@ -1117,7 +1117,7 @@ static void HTTPServerOptions(STREAM *S,HTTPSession *ClientHeads)
     char *Tempstr=NULL;
 
     STREAMWriteLine("HTTP/1.1 200 OK\r\n",S);
-    HTTPServerSendHeader(S, "Date", GetDateStr("Date: %a, %d %b %Y %H:%M:%S %Z",NULL));
+    HTTPServerSendHeader(S, "Date", GetDateStr("Date: %a, %d %b %Y %H:%M:%S %Z",Settings.Timezone));
     HTTPServerSendHeader(S, "Content-Length", "0");
     HTTPServerSendHeader(S, "Public", "OPTIONS, TRACE, GET, HEAD, DELETE, PUT, POST, COPY, MOVE, MKCOL, PROPFIND, PROPPATCH, LOCK, UNLOCK, SEARCH, MKCALENDAR, REPORT, calendar-access");
     HTTPServerSendHeader(S, "Allow", "OPTIONS, TRACE, GET, HEAD, DELETE, PUT, POST, COPY, MOVE, MKCOL, PROPFIND, PROPPATCH, LOCK, UNLOCK, SEARCH, MKCALENDAR, REPORT, calendar-access");


### PR DESCRIPTION
The server shows all dates in the interface in GMT only and completely ignores the timezone settings.
The patch fixes this by allowing dates to be displayed in local time. 